### PR TITLE
email.js tls fix

### DIFF
--- a/handlers/email.js
+++ b/handlers/email.js
@@ -6,15 +6,17 @@ const config = require('../config.json');
 async function getSMTPSettings() {
   const smtpSettings = await db.get('smtp_settings');
   const name = await db.get('name') || 'Skyport';
-
+  let secure = true
   if (!smtpSettings) {
     throw new Error('SMTP settings not found');
   }
-
+  if (smtpSettings.port == 587 || smtpSettings.port == 25) {
+    secure = false
+  } 
   const transporter = nodemailer.createTransport({
     host: smtpSettings.server,
     port: smtpSettings.port,
-    secure: true,
+    secure: secure,
     auth: {
       user: smtpSettings.username,
       pass: smtpSettings.password,


### PR DESCRIPTION
added condition to check if the port was 587 or 25 to disable the secure variable as mentioned in the nodemailer doc:

secure – if true the connection will use TLS when connecting to server. If false (the default) then TLS is used if server supports the STARTTLS extension. In most cases set this value to true if you are connecting to port 465. For port 587 or 25 keep it false

https://nodemailer.com/smtp/#:~:text=secure%20%E2%80%93%20if%20true%20the%20connection%20will%20use,For%20port%20587%20or%2025%20keep%20it%20false